### PR TITLE
Fix navbar positioning and hero section viewport fit

### DIFF
--- a/css/fixes.css
+++ b/css/fixes.css
@@ -1220,7 +1220,7 @@ html {
     z-index: 2;
 }
 
-.section-badge {
+.nri-section .section-badge {
     display: inline-block !important;
     background: linear-gradient(135deg, rgba(255, 255, 255, 0.25), rgba(255, 255, 255, 0.15)) !important;
     color: #ffffff !important;
@@ -1953,5 +1953,167 @@ html {
     .info-box,
     .content-text {
         width: 100% !important;
+    }
+}
+
+/* ===================================
+   HEADER & HERO LAYOUT FIXES
+   =================================== */
+
+/* 1. Make navbar persistent (fixed to top) */
+.navbar {
+    position: fixed !important;
+    top: 0;
+    left: 0;
+    right: 0;
+    width: 100%;
+    z-index: 1020 !important;
+}
+
+/* Push all page content below the fixed navbar using body padding */
+body {
+    padding-top: 76px !important;
+}
+
+/* 2. Nav menu in single row - reduce gap and link sizing (desktop only) */
+@media (min-width: 769px) {
+    .nav-menu {
+        gap: 4px !important;
+        flex-wrap: nowrap !important;
+    }
+
+    .nav-menu > li > a {
+        font-size: 0.85rem !important;
+        padding: 6px 8px !important;
+        white-space: nowrap !important;
+    }
+
+    .nav-cta .btn {
+        font-size: 0.8rem !important;
+        padding: 8px 12px !important;
+        white-space: nowrap !important;
+    }
+
+    .logo-img {
+        height: 50px !important;
+    }
+}
+
+/* 3. Hero section - fit within viewport on all screens */
+.hero {
+    min-height: calc(100dvh - 76px) !important;
+    display: flex !important;
+    align-items: center !important;
+    padding: var(--spacing-8) 0 !important;
+}
+
+.hero .container {
+    width: 100%;
+}
+
+.hero-content {
+    gap: var(--spacing-6) !important;
+}
+
+.hero-title {
+    font-size: clamp(1.75rem, 3.5vw, 3.5rem) !important;
+    margin-bottom: var(--spacing-3) !important;
+}
+
+.hero-subtitle {
+    margin-bottom: var(--spacing-4) !important;
+}
+
+.trust-badges {
+    margin-bottom: var(--spacing-6) !important;
+}
+
+/* === Responsive adjustments for hero viewport fit === */
+
+/* Tablets and smaller desktops */
+@media (max-width: 1024px) and (min-width: 769px) {
+    .nav-menu {
+        gap: 2px !important;
+    }
+
+    .nav-menu > li > a {
+        font-size: 0.8rem !important;
+        padding: 6px 6px !important;
+    }
+
+    .nav-cta .btn {
+        font-size: 0.75rem !important;
+        padding: 6px 10px !important;
+    }
+
+    .hero {
+        padding: var(--spacing-6) 0 !important;
+    }
+}
+
+/* Mobile */
+@media (max-width: 768px) {
+    body {
+        padding-top: 64px !important;
+    }
+
+    .hero {
+        min-height: calc(100dvh - 64px) !important;
+        padding: var(--spacing-6) 0 !important;
+    }
+
+    .hero-title {
+        font-size: clamp(1.5rem, 5vw, 2rem) !important;
+        margin-bottom: var(--spacing-2) !important;
+    }
+
+    .hero-subtitle {
+        font-size: 0.95rem !important;
+        margin-bottom: var(--spacing-3) !important;
+    }
+
+    .hero-badge {
+        font-size: 0.7rem !important;
+        padding: 6px 14px !important;
+        margin-bottom: var(--spacing-3) !important;
+    }
+
+    .trust-badges {
+        margin-bottom: var(--spacing-4) !important;
+        gap: var(--spacing-2) !important;
+    }
+
+    .badge-item {
+        padding: 6px 12px !important;
+        font-size: 0.8rem !important;
+    }
+
+    .hero-ctas {
+        gap: var(--spacing-2) !important;
+    }
+
+    .hero-ctas .btn {
+        padding: 10px 16px !important;
+        font-size: 0.9rem !important;
+    }
+}
+
+/* Short viewport screens (laptops with small height) */
+@media (max-height: 700px) {
+    .hero {
+        padding: var(--spacing-4) 0 !important;
+    }
+
+    .hero-title {
+        font-size: clamp(1.5rem, 3vw, 2.5rem) !important;
+    }
+
+    .trust-badges {
+        margin-bottom: var(--spacing-4) !important;
+    }
+
+    .badge-item {
+        padding: 4px 10px !important;
+        font-size: 0.8rem !important;
     }
 }

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
     <style>
     *{margin:0;padding:0;box-sizing:border-box}
     html{scroll-behavior:smooth}
-    body{font-family:var(--font-family-primary);font-size:var(--font-size-base);line-height:var(--line-height-normal);color:var(--color-neutral-900);background:var(--color-neutral-0);overflow-x:hidden}
+    body{font-family:var(--font-family-primary);font-size:var(--font-size-base);line-height:var(--line-height-normal);color:var(--color-neutral-900);background:var(--color-neutral-0);overflow-x:hidden;padding-top:76px}
     .container{max-width:var(--container-max-width);margin:0 auto;padding:0 var(--spacing-6)}
     h1,h2,h3,h4,h5,h6{font-family:var(--font-family-secondary);font-weight:var(--font-weight-semibold);line-height:var(--line-height-tight);margin-bottom:var(--spacing-4)}
     h1{font-size:clamp(2rem,5vw,3.5rem)}
@@ -61,15 +61,15 @@
     .language-switch{display:flex;gap:var(--spacing-1)}
     .lang-btn{background:transparent;color:var(--color-neutral-0);border:1px solid rgba(255,255,255,0.3);padding:var(--spacing-1) var(--spacing-3);border-radius:var(--radius-sm);cursor:pointer;font-size:var(--font-size-sm);transition:all var(--duration-base) var(--timing-ease)}
     .lang-btn.active,.lang-btn:hover{background:var(--color-primary-500);border-color:var(--color-primary-500)}
-    .navbar{background:var(--color-neutral-0);box-shadow:var(--shadow-sm);position:sticky;top:0;z-index:var(--z-index-sticky)}
+    .navbar{background:var(--color-neutral-0);box-shadow:var(--shadow-sm);position:fixed;top:0;left:0;right:0;width:100%;z-index:1020}
     .nav-wrapper{display:flex;align-items:center;justify-content:space-between;padding:var(--spacing-4) 0}
     .logo-img{height:60px;width:auto}
-    .nav-menu{display:flex;list-style:none;gap:var(--spacing-8);align-items:center}
+    .nav-menu{display:flex;list-style:none;gap:4px;align-items:center;flex-wrap:nowrap}
     .nav-menu a{color:var(--color-neutral-900);font-weight:var(--font-weight-medium);transition:color var(--duration-base) var(--timing-ease);display:flex;align-items:center;gap:var(--spacing-1);text-decoration:none}
     .nav-menu a:hover,.nav-menu a.active{color:var(--color-primary-500)}
     .mobile-menu-toggle{display:none;flex-direction:column;gap:5px;background:transparent;border:none;cursor:pointer;padding:var(--spacing-3);min-width:var(--touch-target-min);min-height:var(--touch-target-min);justify-content:center;align-items:center;z-index:calc(var(--z-index-sticky) + 1);position:relative}
     .mobile-menu-toggle span{display:block;width:28px;height:3px;background:var(--color-neutral-900);border-radius:var(--radius-full);transition:all var(--duration-base) var(--timing-ease);transform-origin:center}
-    .hero{padding:var(--spacing-16) 0;background:linear-gradient(135deg,#1a365d 0%,#1e4a7a 25%,#0066CC 60%,#0052A3 100%);position:relative;overflow:hidden}
+    .hero{padding:var(--spacing-8) 0;min-height:calc(100dvh - 76px);display:flex;align-items:center;background:linear-gradient(135deg,#1a365d 0%,#1e4a7a 25%,#0066CC 60%,#0052A3 100%);position:relative;overflow:hidden}
     .hero-content{display:grid;grid-template-columns:1fr;gap:var(--spacing-12);align-items:center;position:relative;z-index:1;text-align:center;max-width:900px;margin:0 auto}
     .hero-title{margin-bottom:var(--spacing-4);color:var(--color-neutral-0);text-shadow:0 2px 8px rgba(0,0,0,0.5),0 4px 16px rgba(0,0,0,0.3);font-weight:var(--font-weight-bold)}
     .hero-subtitle{font-size:var(--font-size-xl);color:var(--color-neutral-0);margin-bottom:var(--spacing-8);text-shadow:0 2px 6px rgba(0,0,0,0.4),0 1px 3px rgba(0,0,0,0.3);font-weight:var(--font-weight-medium)}


### PR DESCRIPTION
## Summary
This PR fixes the navbar and hero section layout to ensure proper viewport coverage and prevent content overlap. The navbar is now fixed to the top of the page, and the hero section is adjusted to fit within the remaining viewport space on all screen sizes.

## Key Changes

- **Navbar positioning**: Changed from `sticky` to `fixed` positioning with proper z-index (1020) to keep it persistently visible at the top
- **Body padding**: Added `padding-top: 76px` to prevent content from being hidden behind the fixed navbar
- **Hero section sizing**: Updated to use `min-height: calc(100dvh - 76px)` with flexbox centering to fill the viewport below the navbar
- **Navigation menu optimization**: Reduced gap from `var(--spacing-8)` to `4px` and added `flex-wrap: nowrap` to fit menu items in a single row on desktop
- **Responsive adjustments**: 
  - Desktop (769px+): Reduced font sizes and padding for nav items to fit in single row
  - Tablet (769px-1024px): Further reduced spacing and font sizes
  - Mobile (≤768px): Adjusted navbar height to 64px, hero to `calc(100dvh - 64px)`, and scaled typography with `clamp()` functions
  - Short viewports (≤700px height): Reduced padding and margins to accommodate limited vertical space
- **Section badge specificity**: Updated `.section-badge` selector to `.nri-section .section-badge` to increase CSS specificity

## Implementation Details

- Used CSS custom properties (`--spacing-*` variables) for consistent spacing
- Implemented `clamp()` functions for responsive typography that scales smoothly across breakpoints
- Applied `!important` flags in fixes.css to override existing styles
- Used `100dvh` (dynamic viewport height) instead of `100vh` for better mobile browser compatibility
- Maintained touch target minimums for mobile navigation elements

https://claude.ai/code/session_01BtVpgA6siyeXhc9un9Ar8r